### PR TITLE
FileBackend should close all the files it opens

### DIFF
--- a/lib/soup/backends/file_backend.rb
+++ b/lib/soup/backends/file_backend.rb
@@ -54,20 +54,23 @@ class Soup
       end
 
       def load_snip_from_path(path, name)
-        file = File.new(path)
-        data = file.read
-        default_attributes = {:name => name, :updated_at => file.mtime, :created_at => file.mtime}
-        if attribute_start = data.index("\n:")
-          content = data[0, attribute_start].strip
-          attributes = default_attributes.merge(YAML.load(data[attribute_start, data.length]))
-        else
-          content = data
-          attributes = default_attributes
+        snip = nil
+        File.open(path) do |file|
+          data = file.read
+          default_attributes = {:name => name, :updated_at => file.mtime, :created_at => file.mtime}
+          if attribute_start = data.index("\n:")
+            content = data[0, attribute_start].strip
+            attributes = default_attributes.merge(YAML.load(data[attribute_start, data.length]))
+          else
+            content = data
+            attributes = default_attributes
+          end
+          attributes.update(:content => content) if content && content.length > 0
+          extension = File.extname(path).gsub(/^\./, '')
+          attributes.update(:extension => extension) if extension != "snip"
+          snip = Snip.new(attributes, self)
         end
-        attributes.update(:content => content) if content && content.length > 0
-        extension = File.extname(path).gsub(/^\./, '')
-        attributes.update(:extension => extension) if extension != "snip"
-        Snip.new(attributes, self)
+        snip
       end
 
       def path_for(name, extension=nil)


### PR DESCRIPTION
This was causing a number of apparently unrelated exceptions with [our website][1] which uses [vanilla-rb][2] when the OS ran out of file handles.

A simple way to reproduce the problem is to reduce the number of file handles available in your OS, e.g. using `ulimit -n 16` on OSX.

I think there are at least a couple of possible failure modes, but the one we've definitely seen is where the call to `Dir::[]` in `FileBackend#snip_paths` erroneously returns an empty array because the OS has run out of file handles. It seems odd that this just silently fails and doesn't raise an exception. I might submit a bug report to Ruby about this. You can see a simple demonstration of the problem [here][3].

I can imagine scenarios in which the call to `File.new` in `FileBackend#load_snip_from_path` might raise the following exception:

    Errno::EMFILE: Too many open files

We haven't actually seen this exception occur, but it's possible that's because vanilla-rb is swallowing it.

I haven't bothered to write an explicit test for this change, because it feels as if it's just good practice in Ruby to ensure all files are closed.

It doesn't look as if any of the other backend types suffer from the same problem, so I haven't touched them.

Many thanks to @chrisroos for help in diagnosing this problem. Fixes lazyatom/vanilla-rb#10.

[1]: https://github.com/freerange/site
[2]: https://github.com/lazyatom/vanilla-rb
[3]: https://gist.github.com/floehopper/3ee80293e8fee340f0db816977a9b2e9